### PR TITLE
Include version in the app.yaml file

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,6 @@
 runtime: python27
 api_version: 1
+version: 1
 threadsafe: true
 
 handlers:


### PR DESCRIPTION
Without the version info, the deploy end up with Error 400, complaining
that a version for the backend is necessary